### PR TITLE
feat(login & search): add constant login state in header and sorting via url params

### DIFF
--- a/src/app/[locale]/list/_components/AasList.tsx
+++ b/src/app/[locale]/list/_components/AasList.tsx
@@ -50,6 +50,7 @@ export default function AasList(props: AasListProps) {
     const locale = useLocale();
     const MAX_SELECTED_ITEMS = 3;
 
+    // Set initial state for sorting based on url params
     const [sortColumn, setSortColumn] = useState<SortableColumn | null>(props.initialSortOrder ? props.initialSortOrder.column : null);
     const [sortOrder, setSortOrder] = useState<SortOrder>(props.initialSortOrder ? props.initialSortOrder.order : 'asc');
 

--- a/src/app/[locale]/list/_components/AasList.tsx
+++ b/src/app/[locale]/list/_components/AasList.tsx
@@ -25,10 +25,16 @@ type AasListProps = {
     comparisonFeatureFlag?: boolean;
     selectedAasList: string[] | undefined;
     updateSelectedAasList: (isChecked: boolean, aasId: string | undefined) => void;
+    initialSortOrder?: {
+        column: SortableColumn,
+        order: SortOrder,
+    },
+    columnSortUpdateCallback: (column: SortableColumn, order: SortOrder) => void;
 };
+export const sortableColumns: string[] = ['manufacturer', 'productDesignation', 'assetId', 'aasId'];
 
-type SortOrder = 'asc' | 'desc';
-type SortableColumn = 'manufacturer' | 'productDesignation' | 'assetId' | 'aasId';
+export type SortOrder = 'asc' | 'desc';
+export type SortableColumn = (typeof sortableColumns)[number];
 
 type EnrichedListEntity = {
     aasId: string;
@@ -44,8 +50,8 @@ export default function AasList(props: AasListProps) {
     const locale = useLocale();
     const MAX_SELECTED_ITEMS = 3;
 
-    const [sortColumn, setSortColumn] = useState<SortableColumn | null>(null);
-    const [sortOrder, setSortOrder] = useState<SortOrder>('asc');
+    const [sortColumn, setSortColumn] = useState<SortableColumn | null>(props.initialSortOrder ? props.initialSortOrder.column : null);
+    const [sortOrder, setSortOrder] = useState<SortOrder>(props.initialSortOrder ? props.initialSortOrder.order : 'asc');
 
     // Fetch nameplate data for all shells
     const { data: nameplateData, isLoading: isNameplateLoading } = useSWR(
@@ -114,8 +120,9 @@ export default function AasList(props: AasListProps) {
             setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
         } else {
             setSortColumn(column);
-            setSortOrder('asc');
+            setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
         }
+        props.columnSortUpdateCallback(column, sortOrder === 'asc' ? 'desc' : 'asc');
     };
 
     const tableHeaders = [

--- a/src/app/[locale]/list/_components/AasListDataWrapper.tsx
+++ b/src/app/[locale]/list/_components/AasListDataWrapper.tsx
@@ -4,7 +4,7 @@ import { getAasListEntities } from 'lib/services/list-service/aasListApiActions'
 import { useShowError } from 'lib/hooks/UseShowError';
 import { useState } from 'react';
 import { CenteredLoadingSpinner } from 'components/basics/CenteredLoadingSpinner';
-import AasList from './AasList';
+import AasList, { SortOrder, SortableColumn, sortableColumns } from './AasList';
 import { useEnv } from 'app/EnvProvider';
 import { AasListComparisonHeader } from './AasListComparisonHeader';
 import { Box, Card, CardContent, IconButton, MenuItem, Select, Typography } from '@mui/material';
@@ -16,11 +16,15 @@ import { ApiResponseWrapperError } from 'lib/util/apiResponseWrapper/apiResponse
 import { AuthenticationPrompt } from 'components/authentication/AuthenticationPrompt';
 import { ApiResultStatus } from 'lib/util/apiResponseWrapper/apiResultStatus';
 import { useSearchParams } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation'
 
 type AasListDataWrapperProps = {
-  repositoryUrl?: string;
-  hideRepoSelection?: boolean;
+    repositoryUrl?: string;
+    hideRepoSelection?: boolean;
 };
+
+const SEARCH_PARAM_SORT_BY_NAME: string = 'sortby'
+const SEARCH_PARAM_ORDER_NAME: string = 'order'
 
 export default function AasListDataWrapper({ repositoryUrl, hideRepoSelection }: AasListDataWrapperProps) {
     const [isLoadingList, setIsLoadingList] = useState(false);
@@ -29,10 +33,12 @@ export default function AasListDataWrapper({ repositoryUrl, hideRepoSelection }:
     const [selectedAasList, setSelectedAasList] = useState<string[]>();
     const searchParams = useSearchParams();
     const urlParam = searchParams?.get('url');
-    const [selectedRepository, setSelectedRepository] = useState<string | null |undefined>(repositoryUrl ? repositoryUrl : urlParam);
+    const [selectedRepository, setSelectedRepository] = useState<string | null | undefined>(repositoryUrl ? repositoryUrl : urlParam);
     const env = useEnv();
     const t = useTranslations('pages.aasList');
     const { showError } = useShowError();
+    const router = useRouter();
+    const pathname = usePathname();
 
     //Pagination
     const [currentCursor, setCurrentCursor] = useState<string>();
@@ -42,6 +48,34 @@ export default function AasListDataWrapper({ repositoryUrl, hideRepoSelection }:
 
     //Authentication
     const [needAuthentication, setNeedAuthentication] = useState<boolean>(false);
+
+    // checks the passed sorting params and returns an object if valid
+    const checkSortingParams = () => {
+        const sortBy = searchParams?.get(SEARCH_PARAM_SORT_BY_NAME);
+        const sortOrder = searchParams?.get(SEARCH_PARAM_ORDER_NAME);
+        // Check for valid data
+        if (sortBy &&
+            sortOrder &&
+            sortableColumns.includes(sortBy as SortableColumn) &&
+            ['asc', 'desc'].includes(sortOrder as SortOrder)
+        ) {
+            // Return valid props
+            return {
+                column: sortBy as SortableColumn,
+                order: sortOrder as SortOrder,
+            }
+        } else {
+            // invalid data
+            return undefined;
+        }
+    }
+
+    const updateSortingParams = (column: SortableColumn, order: SortOrder) => {
+        const params = new URLSearchParams(searchParams?.toString());
+        params.set(SEARCH_PARAM_SORT_BY_NAME, column);
+        params.set(SEARCH_PARAM_ORDER_NAME, order);
+        router.replace(`${pathname}?${params.toString()}`);
+    }
 
     const clearResults = () => {
         setAasList(undefined);
@@ -165,6 +199,8 @@ export default function AasListDataWrapper({ repositoryUrl, hideRepoSelection }:
                     selectedAasList={selectedAasList}
                     updateSelectedAasList={updateSelectedAasList}
                     comparisonFeatureFlag={env.COMPARISON_FEATURE_FLAG}
+                    initialSortOrder={checkSortingParams()}
+                    columnSortUpdateCallback={updateSortingParams}
                 ></AasList>
                 {pagination}
             </>

--- a/src/app/[locale]/list/_components/AasListDataWrapper.tsx
+++ b/src/app/[locale]/list/_components/AasListDataWrapper.tsx
@@ -70,6 +70,7 @@ export default function AasListDataWrapper({ repositoryUrl, hideRepoSelection }:
         }
     }
 
+    /// Updates the sorting parameters in the url based on user selection
     const updateSortingParams = (column: SortableColumn, order: SortOrder) => {
         const params = new URLSearchParams(searchParams?.toString());
         params.set(SEARCH_PARAM_SORT_BY_NAME, column);

--- a/src/components/basics/listBasics/GenericAasList.tsx
+++ b/src/components/basics/listBasics/GenericAasList.tsx
@@ -1,7 +1,8 @@
-﻿import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
+﻿import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TableSortLabel } from '@mui/material';
 import { GenericAasListEntry } from 'components/basics/listBasics/GenericAasListEntry';
 import { AasListConfig, AasListEntry } from 'lib/types/AasListEntry';
 import { useTranslations } from 'next-intl';
+import { useState, useMemo } from 'react';
 
 type AasListProps = {
     data: AasListEntry[];
@@ -16,6 +17,48 @@ const tableHeaderText = {
 
 export default function GenericAasList({ data, ...config }: AasListProps) {
     const t = useTranslations('pages.aasList.listHeader');
+    const [orderBy, setOrderBy] = useState<string | null>(null);
+    const [order, setOrder] = useState<'asc' | 'desc'>('asc');
+
+    const handleRequestSort = (property: string) => {
+        if (orderBy === property) {
+            setOrder((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+        } else {
+            setOrderBy(property);
+            setOrder('asc');
+        }
+    };
+
+    const getValue = (entry: AasListEntry, property: string) => {
+        switch (property) {
+            case 'picture':
+                return entry.thumbnailUrl ?? '';
+            case 'aasId':
+                return entry.aasId ?? '';
+            case 'assetId':
+                return entry.assetId ?? '';
+            case 'aasEndpoint':
+                return entry.aasEndpoint ?? '';
+            case 'repositoryUrl':
+                return entry.repositoryUrl ?? '';
+            case 'discoveryUrl':
+                return entry.discoveryUrl ?? '';
+            case 'registryUrl':
+                return entry.registryUrl ?? '';
+            default:
+                return '';
+        }
+    };
+
+    const sortedData = useMemo(() => {
+        if (!orderBy) return data;
+        const sorted = [...data].sort((a, b) => {
+            const av = getValue(a, orderBy).toString();
+            const bv = getValue(b, orderBy).toString();
+            return order === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av);
+        });
+        return sorted;
+    }, [data, orderBy, order]);
 
     return (
         <>
@@ -25,37 +68,79 @@ export default function GenericAasList({ data, ...config }: AasListProps) {
                         <TableRow>
                             {config.showThumbnail && (
                                 <TableCell sx={tableHeaderText} data-testid="list-header-picture">
-                                    {t('picture')}
+                                    <TableSortLabel
+                                        active={orderBy === 'picture'}
+                                        direction={orderBy === 'picture' ? order : 'asc'}
+                                        onClick={() => handleRequestSort('picture')}
+                                    >
+                                        {t('picture')}
+                                    </TableSortLabel>
                                 </TableCell>
                             )}
                             {config.showAasId && (
                                 <TableCell sx={tableHeaderText} data-testid="list-header-aasId">
-                                    {t('aasId')}
+                                    <TableSortLabel
+                                        active={orderBy === 'aasId'}
+                                        direction={orderBy === 'aasId' ? order : 'asc'}
+                                        onClick={() => handleRequestSort('aasId')}
+                                    >
+                                        {t('aasId')}
+                                    </TableSortLabel>
                                 </TableCell>
                             )}
                             {config.showAssetId && (
                                 <TableCell sx={tableHeaderText} data-testid="list-header-assetId">
-                                    {t('assetId')}
+                                    <TableSortLabel
+                                        active={orderBy === 'assetId'}
+                                        direction={orderBy === 'assetId' ? order : 'asc'}
+                                        onClick={() => handleRequestSort('assetId')}
+                                    >
+                                        {t('assetId')}
+                                    </TableSortLabel>
                                 </TableCell>
                             )}
                             {config.showAasEndpoint && (
                                 <TableCell sx={tableHeaderText} data-testid="list-header-aasEndpoint">
-                                    {t('aasEndpoint')}
+                                    <TableSortLabel
+                                        active={orderBy === 'aasEndpoint'}
+                                        direction={orderBy === 'aasEndpoint' ? order : 'asc'}
+                                        onClick={() => handleRequestSort('aasEndpoint')}
+                                    >
+                                        {t('aasEndpoint')}
+                                    </TableSortLabel>
                                 </TableCell>
                             )}
                             {config.showRepositoryUrl && (
                                 <TableCell sx={tableHeaderText} data-testid="list-header-repositoryUrl">
-                                    {t('repositoryUrl')}
+                                    <TableSortLabel
+                                        active={orderBy === 'repositoryUrl'}
+                                        direction={orderBy === 'repositoryUrl' ? order : 'asc'}
+                                        onClick={() => handleRequestSort('repositoryUrl')}
+                                    >
+                                        {t('repositoryUrl')}
+                                    </TableSortLabel>
                                 </TableCell>
                             )}
                             {config.showDiscoveryUrl && (
                                 <TableCell sx={tableHeaderText} data-testid="list-header-discoveryUrl">
-                                    {t('discoveryUrl')}
+                                    <TableSortLabel
+                                        active={orderBy === 'discoveryUrl'}
+                                        direction={orderBy === 'discoveryUrl' ? order : 'asc'}
+                                        onClick={() => handleRequestSort('discoveryUrl')}
+                                    >
+                                        {t('discoveryUrl')}
+                                    </TableSortLabel>
                                 </TableCell>
                             )}
                             {config.showRegistryUrl && (
                                 <TableCell sx={tableHeaderText} data-testid="list-header-registryUrl">
-                                    {t('registryUrl')}
+                                    <TableSortLabel
+                                        active={orderBy === 'registryUrl'}
+                                        direction={orderBy === 'registryUrl' ? order : 'asc'}
+                                        onClick={() => handleRequestSort('registryUrl')}
+                                    >
+                                        {t('registryUrl')}
+                                    </TableSortLabel>
                                 </TableCell>
                             )}
                             <TableCell sx={tableHeaderText} data-testid="list-header-viewAASButton">
@@ -64,9 +149,9 @@ export default function GenericAasList({ data, ...config }: AasListProps) {
                         </TableRow>
                     </TableHead>
                     <TableBody>
-                        {data.map((aasListEntry, index) => (
+                        {sortedData.map((aasListEntry) => (
                             <TableRow
-                                key={index}
+                                key={aasListEntry.aasId}
                                 sx={{
                                     '&:last-child td, &:last-child th': { border: 0 },
                                 }}

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -2,6 +2,11 @@ import { AppBar, Box, styled, Toolbar } from '@mui/material';
 import MainMenu from './menu/MainMenu';
 import { HeaderLogo } from './HeaderLogo';
 import { LanguageSelector } from './LanguageSelector';
+import BottomMenu from './menu/BottomMenu';
+import { MnestixRole } from 'components/authentication/AllowedRoutes';
+import { useAuth } from 'lib/hooks/UseAuth';
+//import LoginButton from './LoginButton';
+import { useEnv } from 'app/EnvProvider';
 
 const Offset = styled(Box)(({ theme }) => theme.mixins.toolbar);
 
@@ -18,6 +23,17 @@ const StyledLogoWrapper = styled(Box)(() => ({
 }));
 
 export function Header() {
+    const auth = useAuth();
+    const env = useEnv();
+    const useAuthentication = env.AUTHENTICATION_FEATURE_FLAG;
+    const mnestixRole = auth.getAccount()?.user.mnestixRole ?? MnestixRole.MnestixGuest;
+    const getAuthName = () => {
+        const user = auth?.getAccount()?.user;
+        if (!user) return;
+        if (user.email) return user.email;
+        if (user.name) return user.name;
+        return;
+    };
     return (
         <>
             <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
@@ -36,6 +52,14 @@ export function Header() {
                             <HeaderLogo />
                         </Box>
                     </StyledLogoWrapper>
+                    {
+                        // Change to ButtomMenu if new Button is not finished with first presentation
+                        useAuthentication && <BottomMenu
+                            mnestixRole={mnestixRole}
+                            name={getAuthName() ?? ''}
+                            isLoggedIn={auth.isLoggedIn}
+                        />
+                    }
                     <LanguageSelector />
                 </Toolbar>
             </AppBar>

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -2,10 +2,10 @@ import { AppBar, Box, styled, Toolbar } from '@mui/material';
 import MainMenu from './menu/MainMenu';
 import { HeaderLogo } from './HeaderLogo';
 import { LanguageSelector } from './LanguageSelector';
-import BottomMenu from './menu/BottomMenu';
 import { MnestixRole } from 'components/authentication/AllowedRoutes';
 import { useAuth } from 'lib/hooks/UseAuth';
-//import LoginButton from './LoginButton';
+import LoginButton from './LoginButton';
+import { useIsMobile } from 'lib/hooks/UseBreakpoints';
 import { useEnv } from 'app/EnvProvider';
 
 const Offset = styled(Box)(({ theme }) => theme.mixins.toolbar);
@@ -24,6 +24,7 @@ const StyledLogoWrapper = styled(Box)(() => ({
 
 export function Header() {
     const auth = useAuth();
+    const isMobile = useIsMobile();
     const env = useEnv();
     const useAuthentication = env.AUTHENTICATION_FEATURE_FLAG;
     const mnestixRole = auth.getAccount()?.user.mnestixRole ?? MnestixRole.MnestixGuest;
@@ -38,29 +39,39 @@ export function Header() {
         <>
             <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
                 <Toolbar disableGutters>
-                    <MainMenu />
+                    <Box display="flex" alignItems="center">
+                        <MainMenu />
+                        {useAuthentication && !isMobile && (
+                            <LoginButton
+                                mnestixRole={mnestixRole}
+                                name={getAuthName() ?? ''}
+                                isLoggedIn={auth.isLoggedIn}
+                            />
+                        )}
+                    </Box>
                     <StyledLogoWrapper
                         display="flex"
                         alignItems="center"
                         justifyContent="center"
-                        width="100%"
-                        marginRight="18%"
-                        position="absolute"
-                        alignSelf="center"
+                        flexGrow={1}
+                        minWidth={0}
                     >
                         <Box className="logo">
                             <HeaderLogo />
                         </Box>
                     </StyledLogoWrapper>
-                    {
-                        // Change to ButtomMenu if new Button is not finished with first presentation
-                        useAuthentication && <BottomMenu
-                            mnestixRole={mnestixRole}
-                            name={getAuthName() ?? ''}
-                            isLoggedIn={auth.isLoggedIn}
-                        />
-                    }
-                    <LanguageSelector />
+                    <Box display="flex" alignItems="center" marginLeft="auto">
+                        {
+                            useAuthentication && isMobile && (
+                                <LoginButton
+                                    mnestixRole={mnestixRole}
+                                    name={getAuthName() ?? ''}
+                                    isLoggedIn={auth.isLoggedIn}
+                                />
+                            )
+                        }
+                        <LanguageSelector />
+                    </Box>
                 </Toolbar>
             </AppBar>
             <Offset />

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -39,9 +39,11 @@ export function Header() {
         <>
             <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
                 <Toolbar disableGutters>
+                    {/* Login button for desktop */}
                     <Box display="flex" alignItems="center">
                         <MainMenu />
                         {useAuthentication && !isMobile && (
+
                             <LoginButton
                                 mnestixRole={mnestixRole}
                                 name={getAuthName() ?? ''}
@@ -60,6 +62,7 @@ export function Header() {
                             <HeaderLogo />
                         </Box>
                     </StyledLogoWrapper>
+                    {/* Login button for mobile */}
                     <Box display="flex" alignItems="center" marginLeft="auto">
                         {
                             useAuthentication && isMobile && (

--- a/src/layout/LanguageSelector.tsx
+++ b/src/layout/LanguageSelector.tsx
@@ -21,8 +21,8 @@ const languageOptions = [
  * Styled selector -> select component as a dropdown to select language
  */
 const LanguageSelect = styled(Select)(({ theme }) => ({
-    marginLeft: 'auto',
-    marginRight: theme.spacing(2),
+    marginLeft: 0,
+    marginRight: theme.spacing(1.5),
     backgroundColor: 'transparent', //takes background color and does not overlap if mobile is narrow
     borderRadius: 0,
     width: 'auto',

--- a/src/layout/LoginButton.tsx
+++ b/src/layout/LoginButton.tsx
@@ -1,57 +1,86 @@
 import { MnestixRole } from 'components/authentication/AllowedRoutes';
-import { MenuHeading } from './menu/MenuHeading';
-import { Box } from '@mui/system';
+import { Box, Button, Typography } from '@mui/material';
 import { AccountCircle, AdminPanelSettings, Login, Logout } from '@mui/icons-material';
-import { MenuListItem, MenuListItemProps } from './menu/MenuListItem';
+import { alpha } from '@mui/material/styles';
 import { useTranslations } from 'next-intl';
 import { useAuth } from 'lib/hooks/UseAuth';
+import { useIsMobile } from 'lib/hooks/UseBreakpoints';
 
 export default function LoginButton(props: { isLoggedIn: boolean; name: string; mnestixRole: MnestixRole }) {
     const auth = useAuth();
     const t = useTranslations('navigation.mainMenu');
+    const isMobile = useIsMobile();
 
-    const loggedInButtonContent: MenuListItemProps[] = [
-        {
-            label: t('logout'),
-            icon: <Logout data-testid="logout-button" />,
-            onClick: () => auth.logout(),
+    const buttonSx = {
+        color: 'background.default',
+        textTransform: 'none',
+        fontWeight: 700,
+        px: 1.5,
+        py: 0.5,
+        minWidth: 0,
+        '& .MuiButton-startIcon': {
+            color: 'background.default',
+            marginRight: 0.5,
         },
-    ];
 
-    const guestButtonContent: MenuListItemProps[] = [
-        {
-            label: t('login'),
-            icon: <Login data-testid="login-button" />,
-            onClick: () => auth.login(),
+        '&:hover': {
+            backgroundColor: (theme: { palette: { background: { default: string } } }) =>
+                alpha(theme.palette.background.default, 0.12),
         },
-    ];
+    };
 
     return (
-        <>
-            {props.isLoggedIn && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mr: 1 }}>
+            {props.isLoggedIn ? (
                 <>
-                    <MenuHeading marginTop={0}>
-                        <Box component="span" display="flex" gap={1} data-testid="user-info-box" maxWidth={100}>
-                            {props.mnestixRole === MnestixRole.MnestixAdmin ? (
-                                <AdminPanelSettings data-testid="admin-icon" />
-                            ) : (
-                                <AccountCircle data-testid="user-icon" />
-                            )}
-                            {props.name}
-                        </Box>
-                    </MenuHeading>
-                    {loggedInButtonContent.map((props, i) => (
-                        <MenuListItem {...props} key={'adminLoginStateButton' + i} />
-                    ))}
+                    <Box
+                        component="span"
+                        display="inline-flex"
+                        alignItems="center"
+                        gap={0.75}
+                        data-testid="user-info-box"
+                        sx={{
+                            color: 'background.default',
+                            maxWidth: isMobile ? 32 : 180,
+                        }}
+                    >
+                        {props.mnestixRole === MnestixRole.MnestixAdmin ? (
+                            <AdminPanelSettings data-testid="admin-icon" fontSize="small" />
+                        ) : (
+                            <AccountCircle data-testid="user-icon" fontSize="small" />
+                        )}
+                        {!isMobile && (
+                            <Typography
+                                variant="body2"
+                                sx={{
+                                    color: 'background.default',
+                                    whiteSpace: 'nowrap',
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    maxWidth: 140,
+                                }}
+                            >
+                                {props.name}
+                            </Typography>
+                        )}
+                    </Box>
+                    <Button
+                        startIcon={<Logout data-testid="logout-button" />}
+                        onClick={() => auth.logout()}
+                        sx={buttonSx}
+                    >
+                        {t('logout')}
+                    </Button>
                 </>
+            ) : (
+                <Button
+                    startIcon={<Login data-testid="login-button" />}
+                    onClick={() => auth.login()}
+                    sx={buttonSx}
+                >
+                    {t('login')}
+                </Button>
             )}
-            {!props.isLoggedIn && (
-                <div style={{ maxWidth: 250 }}>
-                    {guestButtonContent.map((props, i) => (
-                        <MenuListItem {...props} key={'guestLoginStateButton' + i} />
-                    ))}
-                </div>
-            )}
-        </>
+        </Box>
     );
 }

--- a/src/layout/LoginButton.tsx
+++ b/src/layout/LoginButton.tsx
@@ -1,0 +1,57 @@
+import { MnestixRole } from 'components/authentication/AllowedRoutes';
+import { MenuHeading } from './menu/MenuHeading';
+import { Box } from '@mui/system';
+import { AccountCircle, AdminPanelSettings, Login, Logout } from '@mui/icons-material';
+import { MenuListItem, MenuListItemProps } from './menu/MenuListItem';
+import { useTranslations } from 'next-intl';
+import { useAuth } from 'lib/hooks/UseAuth';
+
+export default function LoginButton(props: { isLoggedIn: boolean; name: string; mnestixRole: MnestixRole }) {
+    const auth = useAuth();
+    const t = useTranslations('navigation.mainMenu');
+
+    const loggedInButtonContent: MenuListItemProps[] = [
+        {
+            label: t('logout'),
+            icon: <Logout data-testid="logout-button" />,
+            onClick: () => auth.logout(),
+        },
+    ];
+
+    const guestButtonContent: MenuListItemProps[] = [
+        {
+            label: t('login'),
+            icon: <Login data-testid="login-button" />,
+            onClick: () => auth.login(),
+        },
+    ];
+
+    return (
+        <>
+            {props.isLoggedIn && (
+                <>
+                    <MenuHeading marginTop={0}>
+                        <Box component="span" display="flex" gap={1} data-testid="user-info-box" maxWidth={100}>
+                            {props.mnestixRole === MnestixRole.MnestixAdmin ? (
+                                <AdminPanelSettings data-testid="admin-icon" />
+                            ) : (
+                                <AccountCircle data-testid="user-icon" />
+                            )}
+                            {props.name}
+                        </Box>
+                    </MenuHeading>
+                    {loggedInButtonContent.map((props, i) => (
+                        <MenuListItem {...props} key={'adminLoginStateButton' + i} />
+                    ))}
+                </>
+            )}
+            {!props.isLoggedIn && (
+                <div style={{ maxWidth: 250 }}>
+                    {guestButtonContent.map((props, i) => (
+                        <MenuListItem {...props} key={'guestLoginStateButton' + i} />
+                    ))}
+                </div>
+            )}
+        </>
+    );
+}


### PR DESCRIPTION
# Description

- Moved the login button and login state indicator from the side bar into the header for better accessibility (closes #1)
- Added the capability to sort the aas list in `./[locale]/list` via the url params `sortby` to indicate the column to sort by and `order` with the values `asc` and `desc` to indicate the sorting order. (closes #8)

## Important

I did not test the login state when logged in yet, due to me not having set up an authentication server to test it for

## Type of change

Please delete options that are not relevant.

-   [x] Minor change (non-breaking change, e.g. documentation adaption)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)

# Checklist:

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [x] My changes contain no console logs
