### PR TITLE
feat(technical-data): update TechnicalData view

### DIFF
--- a/src/app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataDetail.spec.tsx
+++ b/src/app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataDetail.spec.tsx
@@ -173,4 +173,21 @@ describe('TechnicalDataDetail', () => {
         expect(screen.queryByTestId('collapse-all-button')).not.toBeInTheDocument();
         expect(screen.queryByTestId('search-button')).not.toBeInTheDocument();
     });
+
+    it('should include nested SubmodelElementCollection idShorts in expandedItems when expand all is clicked', () => {
+        // Arrange
+        const submodel = technicalDataTestSubmodels.nestedTechnicalData as unknown as Submodel;
+        render(<TechnicalDataDetail submodel={submodel} />);
+
+        // Act
+        fireEvent.click(screen.getByTestId('expand-all-button'));
+
+        // Assert — root section and both nested collections must all be in expandedItems
+        const expandedItems: string[] = JSON.parse(
+            screen.getByTestId('technical-data-detail').getAttribute('data-expanded-items') ?? '[]'
+        );
+        expect(expandedItems).toContain('technicalProperties');
+        expect(expandedItems).toContain('NestedGroup');
+        expect(expandedItems).toContain('DeepNestedGroup');
+    });
 });

--- a/src/app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataDetail.spec.tsx
+++ b/src/app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataDetail.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 import { expect } from '@jest/globals';
 import { TechnicalDataDetail } from './TechnicalDataDetail';
@@ -116,5 +116,61 @@ describe('TechnicalDataDetail', () => {
 
         // Assert
         expect(screen.getByTestId('generic-submodel-detail')).toBeInTheDocument();
+    });
+
+    it('should render expand all, collapse all and search buttons', () => {
+        // Arrange
+        const submodel = technicalDataTestSubmodels.completeTechnicalData as unknown as Submodel;
+
+        // Act
+        render(<TechnicalDataDetail submodel={submodel} />);
+
+        // Assert
+        expect(screen.getByTestId('expand-all-button')).toBeInTheDocument();
+        expect(screen.getByTestId('collapse-all-button')).toBeInTheDocument();
+        expect(screen.getByTestId('search-button')).toBeInTheDocument();
+    });
+
+    it('should expand all sections when expand all button is clicked', () => {
+        // Arrange
+        const submodel = technicalDataTestSubmodels.completeTechnicalData as unknown as Submodel;
+        render(<TechnicalDataDetail submodel={submodel} />);
+
+        // Act
+        fireEvent.click(screen.getByTestId('expand-all-button'));
+
+        // Assert
+        expect(screen.getByTestId('expanded-technicalProperties')).toHaveTextContent('Expanded');
+        expect(screen.getByTestId('expanded-generalInformation')).toHaveTextContent('Expanded');
+        expect(screen.getByTestId('expanded-productClassifications')).toHaveTextContent('Expanded');
+        expect(screen.getByTestId('expanded-furtherInformation')).toHaveTextContent('Expanded');
+    });
+
+    it('should collapse all sections when collapse all button is clicked', () => {
+        // Arrange
+        const submodel = technicalDataTestSubmodels.completeTechnicalData as unknown as Submodel;
+        render(<TechnicalDataDetail submodel={submodel} />);
+
+        // Act
+        fireEvent.click(screen.getByTestId('collapse-all-button'));
+
+        // Assert
+        expect(screen.getByTestId('expanded-technicalProperties')).toHaveTextContent('Collapsed');
+        expect(screen.getByTestId('expanded-generalInformation')).toHaveTextContent('Collapsed');
+        expect(screen.getByTestId('expanded-productClassifications')).toHaveTextContent('Collapsed');
+        expect(screen.getByTestId('expanded-furtherInformation')).toHaveTextContent('Collapsed');
+    });
+
+    it('should not render toolbar buttons when no recognized technical data elements are found', () => {
+        // Arrange
+        const submodel = technicalDataTestSubmodels.unrecognizedData as unknown as Submodel;
+
+        // Act
+        render(<TechnicalDataDetail submodel={submodel} />);
+
+        // Assert
+        expect(screen.queryByTestId('expand-all-button')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('collapse-all-button')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('search-button')).not.toBeInTheDocument();
     });
 });

--- a/src/app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataDetail.tsx
+++ b/src/app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataDetail.tsx
@@ -13,6 +13,7 @@ import {
 } from 'app/[locale]/viewer/_components/submodel/generic-submodel/GenericSubmodelDetailComponent';
 import { Box, IconButton, Tooltip } from '@mui/material';
 import { UnfoldLess, UnfoldMore, Search } from '@mui/icons-material';
+import { collectAllTreeItemIds } from 'app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataTreeItemUtil';
 
 export function TechnicalDataDetail({ submodel }: SubmodelVisualizationProps) {
     const t = useTranslations('components.technicalData');
@@ -30,10 +31,22 @@ export function TechnicalDataDetail({ submodel }: SubmodelVisualizationProps) {
 
     const allSectionIds = useMemo(() => {
         const ids: string[] = [];
-        if (technicalData?.value) ids.push('technicalProperties');
-        if (generalInformation?.value) ids.push('generalInformation');
-        if (productClassifications?.value) ids.push('productClassifications');
-        if (furtherInformation?.value) ids.push('furtherInformation');
+        if (technicalData?.value) {
+            ids.push('technicalProperties');
+            ids.push(...collectAllTreeItemIds(technicalData.value));
+        }
+        if (generalInformation?.value) {
+            ids.push('generalInformation');
+            ids.push(...collectAllTreeItemIds(generalInformation.value));
+        }
+        if (productClassifications?.value) {
+            ids.push('productClassifications');
+            ids.push(...collectAllTreeItemIds(productClassifications.value));
+        }
+        if (furtherInformation?.value) {
+            ids.push('furtherInformation');
+            ids.push(...collectAllTreeItemIds(furtherInformation.value));
+        }
         return ids;
     }, [technicalData, generalInformation, productClassifications, furtherInformation]);
 
@@ -46,7 +59,7 @@ export function TechnicalDataDetail({ submodel }: SubmodelVisualizationProps) {
     }
 
     return (
-        <Box>
+        <Box data-testid='technical-data-detail' data-expanded-items={JSON.stringify(expandedItems)}>
             {!cannotRenderTechnicalData && (
                 <Box display='flex' justifyContent='flex-end' mb={1}>
                     <Tooltip title={t('expandAll')}>

--- a/src/app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataDetail.tsx
+++ b/src/app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataDetail.tsx
@@ -6,11 +6,13 @@ import {
     SubmodelElementCollection,
 } from '@aas-core-works/aas-core3.0-typescript/types';
 import { useTranslations } from 'next-intl';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { TechnicalDataElement } from 'app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataElement';
 import {
     GenericSubmodelDetailComponent
 } from 'app/[locale]/viewer/_components/submodel/generic-submodel/GenericSubmodelDetailComponent';
+import { Box, IconButton, Tooltip } from '@mui/material';
+import { UnfoldLess, UnfoldMore, Search } from '@mui/icons-material';
 
 export function TechnicalDataDetail({ submodel }: SubmodelVisualizationProps) {
     const t = useTranslations('components.technicalData');
@@ -26,47 +28,99 @@ export function TechnicalDataDetail({ submodel }: SubmodelVisualizationProps) {
 
     const cannotRenderTechnicalData = !generalInformation && !technicalData && !productClassifications && !furtherInformation;
 
+    const allSectionIds = useMemo(() => {
+        const ids: string[] = [];
+        if (technicalData?.value) ids.push('technicalProperties');
+        if (generalInformation?.value) ids.push('generalInformation');
+        if (productClassifications?.value) ids.push('productClassifications');
+        if (furtherInformation?.value) ids.push('furtherInformation');
+        return ids;
+    }, [technicalData, generalInformation, productClassifications, furtherInformation]);
+
+    function handleExpandAll() {
+        setExpandedItems(allSectionIds);
+    }
+
+    function handleCollapseAll() {
+        setExpandedItems([]);
+    }
+
     return (
-        <SimpleTreeView expandedItems={expandedItems} onExpandedItemsChange={(_event, itemIds) => setExpandedItems(itemIds)}>
-            {technicalData?.value && (
-                <TechnicalDataElement
-                    label='technicalProperties'
-                    header={t('technicalProperties')}
-                    elements={technicalData.value}
-                    submodelId={submodel.id}
-                    isExpanded={true}
-                    showUnits={true}
-                />
+        <Box>
+            {!cannotRenderTechnicalData && (
+                <Box display='flex' justifyContent='flex-end' mb={1}>
+                    <Tooltip title={t('expandAll')}>
+                        <IconButton
+                            aria-label={t('expandAll')}
+                            onClick={handleExpandAll}
+                            size='small'
+                            data-testid='expand-all-button'
+                        >
+                            <UnfoldMore />
+                        </IconButton>
+                    </Tooltip>
+                    <Tooltip title={t('collapseAll')}>
+                        <IconButton
+                            aria-label={t('collapseAll')}
+                            onClick={handleCollapseAll}
+                            size='small'
+                            data-testid='collapse-all-button'
+                        >
+                            <UnfoldLess />
+                        </IconButton>
+                    </Tooltip>
+                    <Tooltip title={t('search')}>
+                        <IconButton
+                            aria-label={t('search')}
+                            size='small'
+                            data-testid='search-button'
+                        >
+                            <Search />
+                        </IconButton>
+                    </Tooltip>
+                </Box>
             )}
-            {generalInformation?.value && (
-                <TechnicalDataElement
-                    label='generalInformation'
-                    header={t('generalInformation')}
-                    elements={generalInformation.value}
-                    submodelId={submodel.id}
-                    isExpanded={expandedItems.includes('generalInformation')}
-                />
-            )}
-            {productClassifications?.value && (
-                <TechnicalDataElement
-                    label='productClassifications'
-                    header={t('productClassification')}
-                    elements={productClassifications.value}
-                    submodelId={submodel.id}
-                    isExpanded={expandedItems.includes('productClassifications')}
-                />
-            )}
-            {furtherInformation?.value && (
-                <TechnicalDataElement
-                    label='furtherInformation'
-                    header={t('furtherInformation')}
-                    elements={furtherInformation.value}
-                    submodelId={submodel.id}
-                    isExpanded={expandedItems.includes('furtherInformation')}
-                />
-            )}
-            {cannotRenderTechnicalData && <GenericSubmodelDetailComponent submodel={submodel} />}
-        </SimpleTreeView>
+            <SimpleTreeView expandedItems={expandedItems} onExpandedItemsChange={(_event, itemIds) => setExpandedItems(itemIds)}>
+                {technicalData?.value && (
+                    <TechnicalDataElement
+                        label='technicalProperties'
+                        header={t('technicalProperties')}
+                        elements={technicalData.value}
+                        submodelId={submodel.id}
+                        isExpanded={expandedItems.includes('technicalProperties')}
+                        showUnits={true}
+                    />
+                )}
+                {generalInformation?.value && (
+                    <TechnicalDataElement
+                        label='generalInformation'
+                        header={t('generalInformation')}
+                        elements={generalInformation.value}
+                        submodelId={submodel.id}
+                        isExpanded={expandedItems.includes('generalInformation')}
+                    />
+                )}
+                {productClassifications?.value && (
+                    <TechnicalDataElement
+                        label='productClassifications'
+                        header={t('productClassification')}
+                        elements={productClassifications.value}
+                        submodelId={submodel.id}
+                        isExpanded={expandedItems.includes('productClassifications')}
+                    />
+                )}
+                {furtherInformation?.value && (
+                    <TechnicalDataElement
+                        label='furtherInformation'
+                        header={t('furtherInformation')}
+                        elements={furtherInformation.value}
+                        submodelId={submodel.id}
+                        isExpanded={expandedItems.includes('furtherInformation')}
+                    />
+                )}
+                {cannotRenderTechnicalData && <GenericSubmodelDetailComponent submodel={submodel} />}
+            </SimpleTreeView>
+        </Box>
     );
 }
 

--- a/src/app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataTreeItemUtil.test.ts
+++ b/src/app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataTreeItemUtil.test.ts
@@ -1,0 +1,107 @@
+import { collectAllTreeItemIds } from './TechnicalDataTreeItemUtil';
+import { ISubmodelElement } from '@aas-core-works/aas-core3.0-typescript/types';
+
+describe('collectAllTreeItemIds', () => {
+    it('should return an empty array for an empty element list', () => {
+        expect(collectAllTreeItemIds([])).toEqual([]);
+    });
+
+    it('should return an empty array when no collections are present', () => {
+        const elements = [
+            { idShort: 'PropA', modelType: 'Property', valueType: 'xs:string', value: 'a' },
+            { idShort: 'PropB', modelType: 'Property', valueType: 'xs:string', value: 'b' },
+        ] as unknown as ISubmodelElement[];
+
+        expect(collectAllTreeItemIds(elements)).toEqual([]);
+    });
+
+    it('should collect the idShort of a top-level SubmodelElementCollection', () => {
+        const elements = [
+            {
+                idShort: 'GroupA',
+                modelType: 'SubmodelElementCollection',
+                value: [
+                    { idShort: 'PropA', modelType: 'Property', valueType: 'xs:string', value: 'a' },
+                ],
+            },
+        ] as unknown as ISubmodelElement[];
+
+        expect(collectAllTreeItemIds(elements)).toEqual(['GroupA']);
+    });
+
+    it('should recursively collect idShorts from nested SubmodelElementCollections', () => {
+        const elements = [
+            {
+                idShort: 'GroupA',
+                modelType: 'SubmodelElementCollection',
+                value: [
+                    {
+                        idShort: 'NestedGroup',
+                        modelType: 'SubmodelElementCollection',
+                        value: [
+                            {
+                                idShort: 'DeepNestedGroup',
+                                modelType: 'SubmodelElementCollection',
+                                value: [
+                                    { idShort: 'DeepProp', modelType: 'Property', valueType: 'xs:string', value: 'v' },
+                                ],
+                            },
+                        ],
+                    },
+                    { idShort: 'PropA', modelType: 'Property', valueType: 'xs:string', value: 'a' },
+                ],
+            },
+        ] as unknown as ISubmodelElement[];
+
+        expect(collectAllTreeItemIds(elements)).toEqual(['GroupA', 'NestedGroup', 'DeepNestedGroup']);
+    });
+
+    it('should collect idShorts from a SubmodelElementList', () => {
+        const elements = [
+            {
+                idShort: 'MyList',
+                modelType: 'SubmodelElementList',
+                value: [
+                    { idShort: 'Item0', modelType: 'Property', valueType: 'xs:string', value: 'v' },
+                ],
+            },
+        ] as unknown as ISubmodelElement[];
+
+        expect(collectAllTreeItemIds(elements)).toEqual(['MyList']);
+    });
+
+    it('should skip elements with no idShort', () => {
+        const elements = [
+            {
+                modelType: 'SubmodelElementCollection',
+                value: [],
+            },
+        ] as unknown as ISubmodelElement[];
+
+        expect(collectAllTreeItemIds(elements)).toEqual([]);
+    });
+
+    it('should collect ids from multiple sibling collections', () => {
+        const elements = [
+            {
+                idShort: 'GroupA',
+                modelType: 'SubmodelElementCollection',
+                value: [],
+            },
+            {
+                idShort: 'GroupB',
+                modelType: 'SubmodelElementCollection',
+                value: [
+                    {
+                        idShort: 'NestedInB',
+                        modelType: 'SubmodelElementCollection',
+                        value: [],
+                    },
+                ],
+            },
+        ] as unknown as ISubmodelElement[];
+
+        expect(collectAllTreeItemIds(elements)).toEqual(['GroupA', 'GroupB', 'NestedInB']);
+    });
+});
+

--- a/src/app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataTreeItemUtil.ts
+++ b/src/app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataTreeItemUtil.ts
@@ -1,0 +1,33 @@
+import {
+    ISubmodelElement,
+    KeyTypes,
+    SubmodelElementCollection,
+    SubmodelElementList,
+} from '@aas-core-works/aas-core3.0-typescript/types';
+import { getKeyType } from 'lib/util/KeyTypeUtil';
+
+/**
+ * Recursively collects all TreeItem itemIds from a list of submodel elements.
+ * Only SubmodelElementCollection and SubmodelElementList nodes produce expandable
+ * TreeItems, so only their idShorts are collected.
+ *
+ * @param elements - The list of submodel elements to walk.
+ * @returns A flat array of all expandable itemIds (idShorts).
+ */
+export function collectAllTreeItemIds(elements: ISubmodelElement[]): string[] {
+    const ids: string[] = [];
+    for (const element of elements) {
+        const keyType = getKeyType(element);
+        if (keyType === KeyTypes.SubmodelElementCollection || keyType === KeyTypes.SubmodelElementList) {
+            if (element.idShort) {
+                ids.push(element.idShort);
+            }
+            const collection = element as SubmodelElementCollection | SubmodelElementList;
+            if (collection.value) {
+                ids.push(...collectAllTreeItemIds(collection.value));
+            }
+        }
+    }
+    return ids;
+}
+

--- a/src/app/[locale]/viewer/_components/submodel/technical-data/test-submodel/technical-data-test.json
+++ b/src/app/[locale]/viewer/_components/submodel/technical-data/test-submodel/technical-data-test.json
@@ -171,6 +171,54 @@
       }
     ]
   },
+  "nestedTechnicalData": {
+    "id": "test-submodel-id",
+    "idShort": "NestedTechnicalData",
+    "modelType": "Submodel",
+    "submodelElements": [
+      {
+        "idShort": "TechnicalProperties",
+        "semanticId": {
+          "type": "ExternalReference",
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "0173-1#01-AKJ975#001"
+            }
+          ]
+        },
+        "modelType": "SubmodelElementCollection",
+        "value": [
+          {
+            "idShort": "NestedGroup",
+            "modelType": "SubmodelElementCollection",
+            "value": [
+              {
+                "idShort": "DeepNestedGroup",
+                "modelType": "SubmodelElementCollection",
+                "value": [
+                  {
+                    "idShort": "DeepProperty",
+                    "category": "VARIABLE",
+                    "valueType": "xs:string",
+                    "value": "Deep Value",
+                    "modelType": "Property"
+                  }
+                ]
+              },
+              {
+                "idShort": "NestedProperty",
+                "category": "VARIABLE",
+                "valueType": "xs:string",
+                "value": "Nested Value",
+                "modelType": "Property"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
   "unrecognizedData": {
     "id": "test-submodel-id",
     "idShort": "UnrecognizedData",

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -168,7 +168,10 @@
       "furtherInformation": "Weitere Informationen",
       "generalInformation": "Allgemeine Informationen",
       "productClassification": "Produktklassifikation",
-      "technicalProperties": "Technische Eigenschaften"
+      "technicalProperties": "Technische Eigenschaften",
+      "expandAll": "Alle aufklappen",
+      "collapseAll": "Alle zuklappen",
+      "search": "Suchen"
     },
     "verticalTabSelector": {
       "errors": {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -168,7 +168,10 @@
       "furtherInformation": "Further information",
       "generalInformation": "General information",
       "productClassification": "Product classification",
-      "technicalProperties": "Technical properties"
+      "technicalProperties": "Technical properties",
+      "expandAll": "Expand all",
+      "collapseAll": "Collapse all",
+      "search": "Search"
     },
     "verticalTabSelector": {
       "errors": {

--- a/src/locale/es.json
+++ b/src/locale/es.json
@@ -168,7 +168,10 @@
       "furtherInformation": "Más información",
       "generalInformation": "Información general",
       "productClassification": "Clasificación del producto",
-      "technicalProperties": "Propiedades técnicas"
+      "technicalProperties": "Propiedades técnicas",
+      "expandAll": "Expandir todo",
+      "collapseAll": "Contraer todo",
+      "search": "Buscar"
     },
     "verticalTabSelector": {
       "errors": {


### PR DESCRIPTION
# TechnicalData View

The technical data view is a view in `/product/{id}`. The current implementation is not user-friendly (see #15).
This pull request adds three new buttons to the view:

* `Collapse All`: collapses all nested views, only root elements visible
* `Expand All`: expands all nested view including children
* `Search`: search in technical data

> Note: `Search` is currently not woking because functionality not required.
> Button can be removed later if functionality does not go to production code base.

## Screenshot

<img width="1138" height="185" alt="Screenshot 2026-03-01 at 15 56 14" src="https://github.com/user-attachments/assets/6562fd8c-8551-459d-ac80-098cac2be23b" />
