### PR TITLE
feature(product-view): improve sm technical data display

### DIFF
--- a/src/app/[locale]/product/[base64AasId]/page.tsx
+++ b/src/app/[locale]/product/[base64AasId]/page.tsx
@@ -197,6 +197,7 @@ export default function Page() {
                         }
                         catalogConfig={manufacturerInfo}
                     />
+                    
                     <SubmodelsOverviewCard
                         submodelIds={filteredSubmodels}
                         submodelsLoading={isSubmodelsLoading}

--- a/src/app/[locale]/viewer/_components/SubmodelsOverviewCard.tsx
+++ b/src/app/[locale]/viewer/_components/SubmodelsOverviewCard.tsx
@@ -89,15 +89,22 @@ export function SubmodelsOverviewCard({
             );
         } else if (submodelsLoading) {
             return (
-                <Box sx={{ mb: 2 }}>
-                    <Skeleton variant="text" width="50%" />
-                    <Skeleton variant="text" width="30%" />
-                    <Divider sx={{ mt: 2 }} />
-                    <Skeleton variant="text" width="50%" />
-                    <Skeleton variant="text" width="30%" />
-                    <Divider sx={{ mt: 2 }} />
-                    <Skeleton variant="text" width="50%" />
-                    <Skeleton variant="text" width="30%" />
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+                    <Box>
+                        <Skeleton variant="text" width="60%" height={32} sx={{ mb: 1 }} />
+                        <Skeleton variant="text" width="40%" height={20} />
+                    </Box>
+                    <Divider />
+                    <Box>
+                        <Skeleton variant="text" width="50%" height={28} sx={{ mb: 2 }} />
+                        <Skeleton variant="text" width="100%" height={16} sx={{ mb: 1 }} />
+                        <Skeleton variant="text" width="85%" height={16} />
+                    </Box>
+                    <Box>
+                        <Skeleton variant="text" width="50%" height={28} sx={{ mb: 2 }} />
+                        <Skeleton variant="text" width="100%" height={16} sx={{ mb: 1 }} />
+                        <Skeleton variant="text" width="90%" height={16} />
+                    </Box>
                 </Box>
             );
         }
@@ -106,24 +113,76 @@ export function SubmodelsOverviewCard({
 
     return (
         <>
-            <Card>
-                <CardContent>
+            <Card
+                sx={{
+                    boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
+                    borderRadius: '8px',
+                    transition: 'box-shadow 0.3s ease-in-out',
+                    '&:hover': {
+                        boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+                    },
+                }}
+            >
+                <CardContent
+                    sx={{
+                        padding: { xs: '16px', sm: '24px' },
+                        '&:last-child': {
+                            paddingBottom: { xs: '16px', sm: '24px' },
+                        },
+                    }}
+                >
                     {!disableHeadline && (
-                        <Typography variant="h3" marginBottom="15px">
+                        <Typography
+                            variant="h3"
+                            marginBottom="24px"
+                            sx={{
+                                fontWeight: 600,
+                                color: 'text.primary',
+                                fontSize: { xs: '1.5rem', sm: '2rem' },
+                            }}
+                        >
                             {t('title')}
                         </Typography>
                     )}
                     {getSubmodelTabs().length == 0 ? (
                         // Content if there are no submodels to load
-                        <Box display="flex" justifyContent="center" alignItems="center" height="100%">
-                            <Typography variant={'body1'} color="text.secondary">
+                        <Box
+                            display="flex"
+                            justifyContent="center"
+                            alignItems="center"
+                            minHeight="300px"
+                            sx={{
+                                backgroundColor: 'action.hover',
+                                borderRadius: '8px',
+                                padding: '32px',
+                            }}
+                        >
+                            <Typography
+                                variant={'body1'}
+                                color="text.secondary"
+                                textAlign="center"
+                                sx={{ fontSize: '1rem' }}
+                            >
                                 {t('noSubmodelsToLoad')}
                             </Typography>
                         </Box>
                     ) : (
                         // Content if there are submodels
-                        <Box display="grid" gridTemplateColumns={isMobile ? '1fr' : '1fr 2fr'} gap="2rem">
-                            <Box>
+                        <Box
+                            display="grid"
+                            gridTemplateColumns={isMobile ? '1fr' : '350px 1fr'}
+                            gap={{ xs: '16px', sm: '24px' }}
+                            sx={{
+                                minHeight: '400px',
+                            }}
+                        >
+                            <Box
+                                sx={{
+                                    display: 'flex',
+                                    flexDirection: 'column',
+                                    gap: '12px',
+                                }}
+                            >
                                 <VerticalTabSelector
                                     items={submodelSelectorItems}
                                     selected={selectedItem}
@@ -131,27 +190,56 @@ export function SubmodelsOverviewCard({
                                     setInfoItem={setInfoItem}
                                 />
                                 {submodelsLoading && (
-                                    <Skeleton
-                                        height={70}
-                                        sx={{ mb: 2 }}
-                                        data-testid="submodelOverviewLoadingSkeleton"
-                                    />
+                                    <Box
+                                        sx={{
+                                            display: 'flex',
+                                            flexDirection: 'column',
+                                            gap: '12px',
+                                        }}
+                                    >
+                                        <Skeleton
+                                            variant="rectangular"
+                                            height={65}
+                                            sx={{
+                                                borderRadius: '6px',
+                                            }}
+                                            data-testid="submodelOverviewLoadingSkeleton"
+                                        />
+                                        <Skeleton
+                                            variant="rectangular"
+                                            height={65}
+                                            sx={{
+                                                borderRadius: '6px',
+                                            }}
+                                        />
+                                    </Box>
                                 )}
                             </Box>
-                            {isMobile ? (
-                                <MobileModal
-                                    selectedItem={selectedItem}
-                                    open={!!selectedItem}
-                                    handleClose={() => {
-                                        setSelectedItem(undefined);
-                                    }}
-                                    setInfoItem={setInfoItem}
-                                    content={SelectedContent}
-                                />
-                            ) : (
-                                SelectedContent
-                            )}
+                            <Box
+                                sx={{
+                                    display: isMobile ? 'none' : 'block',
+                                    backgroundColor: 'background.default',
+                                    borderRadius: '8px',
+                                    padding: '20px',
+                                    overflow: 'visible',
+                                    borderLeft: '1px solid',
+                                    borderColor: 'divider',
+                                }}
+                            >
+                                {SelectedContent}
+                            </Box>
                         </Box>
+                    )}
+                    {isMobile && (
+                        <MobileModal
+                            selectedItem={selectedItem}
+                            open={!!selectedItem}
+                            handleClose={() => {
+                                setSelectedItem(undefined);
+                            }}
+                            setInfoItem={setInfoItem}
+                            content={SelectedContent}
+                        />
                     )}
                 </CardContent>
             </Card>

--- a/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/FileComponent.tsx
+++ b/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/FileComponent.tsx
@@ -13,8 +13,9 @@ import ImagePreviewDialog from './ImagePreviewDialog';
 const StyledFileImg = styled('img')(() => ({
     objectFit: 'contain',
     objectPosition: 'left top',
-    maxWidth: '100%',
-    maxHeight: '100%',
+    maxWidth: '200px',
+    maxHeight: '200px',
+    borderRadius: '6px',
 }));
 
 type FileComponentProps = {

--- a/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/SubmodelElementCollectionComponent.tsx
+++ b/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/SubmodelElementCollectionComponent.tsx
@@ -1,15 +1,7 @@
-import { KeyboardArrowDown, KeyboardArrowUp } from '@mui/icons-material';
-import { Box, Button } from '@mui/material';
+import { Box } from '@mui/material';
 import { SubmodelElementCollection } from '@aas-core-works/aas-core3.0-typescript/types';
-import { NestedContentWrapper } from 'components/basics/NestedContentWrapper';
-import { ReactNode, useState } from 'react';
+import { ReactNode } from 'react';
 import { GenericSubmodelElementComponent } from './GenericSubmodelElementComponent';
-import { useTranslations } from 'next-intl';
-
-enum ExpandButtonText {
-    show = 'show',
-    hide = 'hide',
-}
 
 type SubmodelElementComponentProps = {
     readonly submodelId?: string;
@@ -22,9 +14,7 @@ export function SubmodelElementCollectionComponent({
     submodelElementPath,
     submodelElementCollection,
 }: SubmodelElementComponentProps) {
-    const [isExpanded, setIsExpanded] = useState(false);
     const componentList: ReactNode[] = [];
-    const t = useTranslations('components.submodelElementCollection');
 
     if (
         !submodelElementCollection.value ||
@@ -46,19 +36,15 @@ export function SubmodelElementCollectionComponent({
     });
 
     return (
-        <Box>
-            <Button
-                variant="outlined"
-                startIcon={isExpanded ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
-                sx={{ my: 1 }}
-                onClick={() => setIsExpanded(!isExpanded)}
-                data-testid="submodel-dropdown-button"
-            >
-                {t(`showEntriesButton.${isExpanded ? ExpandButtonText.hide : ExpandButtonText.show}`, {
-                    count: Object.keys(submodelElementCollection.value).length,
-                })}
-            </Button>
-            {isExpanded && <NestedContentWrapper>{componentList}</NestedContentWrapper>}
+        <Box
+            sx={{
+                display: 'grid',
+                gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+                gap: { xs: 1, sm: 2 },
+                alignItems: 'start',
+            }}
+        >
+            {componentList}
         </Box>
     );
 }

--- a/src/app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataDetail.tsx
+++ b/src/app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataDetail.tsx
@@ -1,23 +1,21 @@
 import { SubmodelVisualizationProps } from 'app/[locale]/viewer/_components/submodel/SubmodelVisualizationProps';
-import { SimpleTreeView } from '@mui/x-tree-view';
 import { hasSemanticId } from 'lib/util/SubmodelResolverUtil';
 import { SubmodelElementSemanticIdEnum } from 'lib/enums/SubmodelElementSemanticId.enum';
 import {
     SubmodelElementCollection,
 } from '@aas-core-works/aas-core3.0-typescript/types';
 import { useTranslations } from 'next-intl';
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import { TechnicalDataElement } from 'app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataElement';
 import {
     GenericSubmodelDetailComponent
 } from 'app/[locale]/viewer/_components/submodel/generic-submodel/GenericSubmodelDetailComponent';
-import { Box, IconButton, Tooltip } from '@mui/material';
-import { UnfoldLess, UnfoldMore, Search } from '@mui/icons-material';
-import { collectAllTreeItemIds } from 'app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataTreeItemUtil';
+import { Box, Accordion, AccordionSummary, AccordionDetails, Typography } from '@mui/material';
+import { ExpandMore } from '@mui/icons-material';
 
 export function TechnicalDataDetail({ submodel }: SubmodelVisualizationProps) {
     const t = useTranslations('components.technicalData');
-    const [expandedItems, setExpandedItems] = useState<string[]>(['technicalProperties']);
+    const [expandedAccordion, setExpandedAccordion] = useState<string | false>('technicalProperties');
 
     const findSubmodelElementBySemanticIdOrIdShort = (semanticId: SubmodelElementSemanticIdEnum, idShort: string) =>
         submodel.submodelElements?.find((el) => hasSemanticId(el, semanticId) || el.idShort === idShort) as SubmodelElementCollection | undefined;
@@ -29,110 +27,108 @@ export function TechnicalDataDetail({ submodel }: SubmodelVisualizationProps) {
 
     const cannotRenderTechnicalData = !generalInformation && !technicalData && !productClassifications && !furtherInformation;
 
-    const allSectionIds = useMemo(() => {
-        const ids: string[] = [];
-        if (technicalData?.value) {
-            ids.push('technicalProperties');
-            ids.push(...collectAllTreeItemIds(technicalData.value));
-        }
-        if (generalInformation?.value) {
-            ids.push('generalInformation');
-            ids.push(...collectAllTreeItemIds(generalInformation.value));
-        }
-        if (productClassifications?.value) {
-            ids.push('productClassifications');
-            ids.push(...collectAllTreeItemIds(productClassifications.value));
-        }
-        if (furtherInformation?.value) {
-            ids.push('furtherInformation');
-            ids.push(...collectAllTreeItemIds(furtherInformation.value));
-        }
-        return ids;
-    }, [technicalData, generalInformation, productClassifications, furtherInformation]);
-
-    function handleExpandAll() {
-        setExpandedItems(allSectionIds);
-    }
-
-    function handleCollapseAll() {
-        setExpandedItems([]);
-    }
+    const handleAccordionChange = (panel: string) => (_event: React.SyntheticEvent, isExpanded: boolean) => {
+        setExpandedAccordion(isExpanded ? panel : false);
+    };
 
     return (
-        <Box data-testid='technical-data-detail' data-expanded-items={JSON.stringify(expandedItems)}>
-            {!cannotRenderTechnicalData && (
-                <Box display='flex' justifyContent='flex-end' mb={1}>
-                    <Tooltip title={t('expandAll')}>
-                        <IconButton
-                            aria-label={t('expandAll')}
-                            onClick={handleExpandAll}
-                            size='small'
-                            data-testid='expand-all-button'
+        <Box data-testid='technical-data-detail' sx={{ width: '100%' }}>
+            {cannotRenderTechnicalData ? (
+                <GenericSubmodelDetailComponent submodel={submodel} />
+            ) : (
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                    {technicalData?.value && (
+                        <Accordion 
+                            expanded={expandedAccordion === 'technicalProperties'} 
+                            onChange={handleAccordionChange('technicalProperties')}
+                            defaultExpanded
+                            sx={{ boxShadow: 'none', border: '1px solid #e0e0e0', '&:before': { display: 'none' } }}
                         >
-                            <UnfoldMore />
-                        </IconButton>
-                    </Tooltip>
-                    <Tooltip title={t('collapseAll')}>
-                        <IconButton
-                            aria-label={t('collapseAll')}
-                            onClick={handleCollapseAll}
-                            size='small'
-                            data-testid='collapse-all-button'
+                            <AccordionSummary expandIcon={<ExpandMore />}>
+                                <Typography variant="h6" sx={{ fontWeight: 600 }}>
+                                    {t('technicalProperties')}
+                                </Typography>
+                            </AccordionSummary>
+                            <AccordionDetails sx={{ backgroundColor: '#fafafa' }}>
+                                <TechnicalDataElement
+                                    label='technicalProperties'
+                                    header={t('technicalProperties')}
+                                    elements={technicalData.value}
+                                    submodelId={submodel.id}
+                                    isExpanded={expandedAccordion === 'technicalProperties'}
+                                    showUnits={true}
+                                />
+                            </AccordionDetails>
+                        </Accordion>
+                    )}
+                    {generalInformation?.value && (
+                        <Accordion 
+                            expanded={expandedAccordion === 'generalInformation'} 
+                            onChange={handleAccordionChange('generalInformation')}
+                            sx={{ boxShadow: 'none', border: '1px solid #e0e0e0', '&:before': { display: 'none' } }}
                         >
-                            <UnfoldLess />
-                        </IconButton>
-                    </Tooltip>
-                    <Tooltip title={t('search')}>
-                        <IconButton
-                            aria-label={t('search')}
-                            size='small'
-                            data-testid='search-button'
+                            <AccordionSummary expandIcon={<ExpandMore />}>
+                                <Typography variant="h6" sx={{ fontWeight: 600 }}>
+                                    {t('generalInformation')}
+                                </Typography>
+                            </AccordionSummary>
+                            <AccordionDetails sx={{ backgroundColor: '#fafafa' }}>
+                                <TechnicalDataElement
+                                    label='generalInformation'
+                                    header={t('generalInformation')}
+                                    elements={generalInformation.value}
+                                    submodelId={submodel.id}
+                                    isExpanded={expandedAccordion === 'generalInformation'}
+                                />
+                            </AccordionDetails>
+                        </Accordion>
+                    )}
+                    {productClassifications?.value && (
+                        <Accordion 
+                            expanded={expandedAccordion === 'productClassifications'} 
+                            onChange={handleAccordionChange('productClassifications')}
+                            sx={{ boxShadow: 'none', border: '1px solid #e0e0e0', '&:before': { display: 'none' } }}
                         >
-                            <Search />
-                        </IconButton>
-                    </Tooltip>
+                            <AccordionSummary expandIcon={<ExpandMore />}>
+                                <Typography variant="h6" sx={{ fontWeight: 600 }}>
+                                    {t('productClassification')}
+                                </Typography>
+                            </AccordionSummary>
+                            <AccordionDetails sx={{ backgroundColor: '#fafafa' }}>
+                                <TechnicalDataElement
+                                    label='productClassifications'
+                                    header={t('productClassification')}
+                                    elements={productClassifications.value}
+                                    submodelId={submodel.id}
+                                    isExpanded={expandedAccordion === 'productClassifications'}
+                                />
+                            </AccordionDetails>
+                        </Accordion>
+                    )}
+                    {furtherInformation?.value && (
+                        <Accordion 
+                            expanded={expandedAccordion === 'furtherInformation'} 
+                            onChange={handleAccordionChange('furtherInformation')}
+                            sx={{ boxShadow: 'none', border: '1px solid #e0e0e0', '&:before': { display: 'none' } }}
+                        >
+                            <AccordionSummary expandIcon={<ExpandMore />}>
+                                <Typography variant="h6" sx={{ fontWeight: 600 }}>
+                                    {t('furtherInformation')}
+                                </Typography>
+                            </AccordionSummary>
+                            <AccordionDetails sx={{ backgroundColor: '#fafafa' }}>
+                                <TechnicalDataElement
+                                    label='furtherInformation'
+                                    header={t('furtherInformation')}
+                                    elements={furtherInformation.value}
+                                    submodelId={submodel.id}
+                                    isExpanded={expandedAccordion === 'furtherInformation'}
+                                />
+                            </AccordionDetails>
+                        </Accordion>
+                    )}
                 </Box>
             )}
-            <SimpleTreeView expandedItems={expandedItems} onExpandedItemsChange={(_event, itemIds) => setExpandedItems(itemIds)}>
-                {technicalData?.value && (
-                    <TechnicalDataElement
-                        label='technicalProperties'
-                        header={t('technicalProperties')}
-                        elements={technicalData.value}
-                        submodelId={submodel.id}
-                        isExpanded={expandedItems.includes('technicalProperties')}
-                        showUnits={true}
-                    />
-                )}
-                {generalInformation?.value && (
-                    <TechnicalDataElement
-                        label='generalInformation'
-                        header={t('generalInformation')}
-                        elements={generalInformation.value}
-                        submodelId={submodel.id}
-                        isExpanded={expandedItems.includes('generalInformation')}
-                    />
-                )}
-                {productClassifications?.value && (
-                    <TechnicalDataElement
-                        label='productClassifications'
-                        header={t('productClassification')}
-                        elements={productClassifications.value}
-                        submodelId={submodel.id}
-                        isExpanded={expandedItems.includes('productClassifications')}
-                    />
-                )}
-                {furtherInformation?.value && (
-                    <TechnicalDataElement
-                        label='furtherInformation'
-                        header={t('furtherInformation')}
-                        elements={furtherInformation.value}
-                        submodelId={submodel.id}
-                        isExpanded={expandedItems.includes('furtherInformation')}
-                    />
-                )}
-                {cannotRenderTechnicalData && <GenericSubmodelDetailComponent submodel={submodel} />}
-            </SimpleTreeView>
         </Box>
     );
 }

--- a/src/app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataElement.tsx
+++ b/src/app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataElement.tsx
@@ -10,11 +10,10 @@ import {
     SubmodelElementCollection,
 } from '@aas-core-works/aas-core3.0-typescript/types';
 import { useTranslations } from 'next-intl';
-import { Box, Typography, useTheme } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import React, { useState } from 'react';
 import { getKeyType } from 'lib/util/KeyTypeUtil';
 import { DataRowWithUnit } from 'app/[locale]/viewer/_components/submodel/technical-data/ConceptDescriptionDataRow';
-import { TreeItem } from '@mui/x-tree-view';
 import { FileComponent } from 'app/[locale]/viewer/_components/submodel-elements/generic-elements/FileComponent';
 import { buildSubmodelElementPath } from 'lib/util/SubmodelResolverUtil';
 import { getConceptDescriptionById } from 'lib/services/conceptDescriptionApiActions';
@@ -30,7 +29,6 @@ export const TechnicalDataElement = (props: {
     showUnits?: boolean
 }) => {
     const t = useTranslations('pages.aasViewer.submodels');
-    const theme = useTheme();
     const [conceptDescriptions, setConceptDescriptions] = useState<Record<string, ConceptDescription>>({});
     const [loadingConceptDescriptions, setLoadingConceptDescriptions] = useState<boolean>(true);
 
@@ -112,29 +110,38 @@ export const TechnicalDataElement = (props: {
             case KeyTypes.SubmodelElementCollection:
             case KeyTypes.SubmodelElementList:
                 return (
-                    <TreeItem
-                        itemId={element.idShort || 'unknown'}
-                        label={element.idShort}
+                    <Box
                         sx={{
-                            '&& .MuiTreeItem-label': {
-                                m: 0,
-                                ...theme.typography.h5,
-                            },
+                            p: 1.5,
+                            border: '1px solid',
+                            borderColor: 'divider',
+                            borderRadius: 1,
+                            backgroundColor: '#fafafa',
                         }}
                     >
-                        {(element as SubmodelElementCollection | SubmodelElementList)?.value?.map(
-                            (child) => child && <React.Fragment key={child.idShort}>{renderSubmodelElement(child)}</React.Fragment>,
-                        )}
-                    </TreeItem>
+                        <Typography variant="h5" sx={{ fontWeight: 600, mb: 1.5, fontSize: '0.95rem' }}>
+                            {element.idShort}
+                        </Typography>
+                        <Box
+                            sx={{
+                                display: 'grid',
+                                gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr', md: 'repeat(3, 1fr)' },
+                                gap: 2,
+                            }}
+                        >
+                            {(element as SubmodelElementCollection | SubmodelElementList)?.value?.map(
+                                (child) => child && <React.Fragment key={child.idShort}>{renderSubmodelElement(child)}</React.Fragment>,
+                            )}
+                        </Box>
+                    </Box>
                 );
             case KeyTypes.File: {
                 const file = element as File;
                 const path = buildSubmodelElementPath('GeneralInformation', element.idShort);
 
                 return (
-                    // With the hardcoded SubmodelElementPath, this only works for CompanyLogo and ProductLogo
                     <DataRowWithUnit submodelElement={element}>
-                        <Box height="50px" overflow="hidden" sx={{ display: 'flex', overflowWrap: 'anywhere' }}>
+                        <Box height="24px" width="24px" overflow="hidden" sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', borderRadius: '3px', backgroundColor: '#f5f5f5', minWidth: '24px' }}>
                             <FileComponent
                                 file={file}
                                 submodelId={props.submodelId}
@@ -182,28 +189,30 @@ export const TechnicalDataElement = (props: {
     };
 
     return (
-        <TreeItem
-            itemId={props.label}
-            label={props.header.toUpperCase()}
-            sx={{
-                '& .MuiTreeItem-content': {
+        <Box>
+            <Typography
+                variant="h4"
+                sx={{
+                    m: 1,
                     py: 1,
+                    textTransform: 'uppercase',
+                    fontWeight: 600,
                     borderBottom: '1px solid',
                     borderColor: 'divider',
-                },
-                '& .MuiTreeItem-content .MuiTreeItem-iconContainer': {
-                    '& svg': {
-                        fontSize: '30px',
-                    },
-                },
-                '&& .MuiTreeItem-label': {
-                    m: 1,
-                    ...theme.typography.h4,
-                },
-            }}
-            key={props.label}
-        >
-            {props.elements?.map((el, index) => el && <React.Fragment key={`${el.idShort}_${index}`}>{renderSubmodelElement(el)}</React.Fragment>)}
-        </TreeItem>
+                }}
+            >
+                {props.header}
+            </Typography>
+            <Box
+                sx={{
+                    display: 'grid',
+                    gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr', md: 'repeat(3, 1fr)' },
+                    gap: 2,
+                    p: 1,
+                }}
+            >
+                {props.elements?.map((el, index) => el && <React.Fragment key={`${el.idShort}_${index}`}>{renderSubmodelElement(el)}</React.Fragment>)}
+            </Box>
+        </Box>
     );
 };


### PR DESCRIPTION
# Description

This PR introduces a more user-friendly design for displaying the technical data of an item.

Previously, users had to click multiple times (up to three interactions) to fully view the data. With this update, the information is now more accessible and easier to navigate, significantly improving the overall user experience.

The differences between the old and new design can be seen in the screenshots below.

### Before
<img width="564" height="253" alt="grafik" src="https://github.com/user-attachments/assets/e6f86833-219f-4760-abf6-0e1e1914a91a" />


### After
<img width="568" height="673" alt="Bildschirmfoto 2026-04-01 um 11 16 52" src="https://github.com/user-attachments/assets/37cce6df-921d-45d9-ae65-b6b4b8caf283" />


Fixes #15 

## Type of change

Please delete options that are not relevant.

-   [ ] Minor change (non-breaking change, e.g. documentation adaption)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)

# Checklist:

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [x] My changes contain no console logs
